### PR TITLE
Removed the AWS roles from staging/main.tf

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -76,23 +76,6 @@ data "aws_ssm_parameter" "uh_test_hostname" {
    }
  }
 
- resource "aws_iam_role" "dms-access-for-endpoint" {
-   assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
-   name               = "dms-access-for-endpoint"
- }
- resource "aws_iam_role_policy_attachment" "dms-access-for-endpoint-AmazonDMSRedshiftS3Role" {
-   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"
-   role       = "${aws_iam_role.dms-access-for-endpoint.name}"
- }
- resource "aws_iam_role" "dms-vpc-role" {
-   assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
-   name               = "dms-vpc-role"
- }
- resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
-   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-   role       = "${aws_iam_role.dms-vpc-role.name}"
- }
-
 /* DMS SET UP INCLUDING DMS INSTANCE AS NONE EXISTS */
 
 module "dms_setup_staging" {


### PR DESCRIPTION
We have decided to removed the AWS roles as this was causing an issue during the CircleCI 'terraform-init-and-apply-to-staging' build.

Let me know if you suggest any further improvements.