### PR TITLE
Change route to match "api/v1" route format for view endpoint

### DIFF
--- a/UHResidentInformationAPI.Tests/V1/E2ETests/GetResidentInformationByIdTests.cs
+++ b/UHResidentInformationAPI.Tests/V1/E2ETests/GetResidentInformationByIdTests.cs
@@ -30,7 +30,7 @@ namespace UHResidentInformationApi.Tests.V1.E2ETests
 
             var expectedResponse = E2ETestHelpers.AddPersonWithRelatedEntitiesToDb(UHContext, houseRef, personNo);
 
-            var uri = new Uri($"/households/{houseRef}/people/{personNo}", UriKind.Relative);
+            var uri = new Uri($"api/v1/households/{houseRef}/people/{personNo}", UriKind.Relative);
             var response = Client.GetAsync(uri);
             var statusCode = response.Result.StatusCode;
             statusCode.Should().Be(200);

--- a/UHResidentInformationAPI/V1/Controllers/UHController.cs
+++ b/UHResidentInformationAPI/V1/Controllers/UHController.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using UHResidentInformationAPI.V1.Domain;
 using UHResidentInformationAPI.V1.Boundary.Requests;
 using UHResidentInformationAPI.V1.Boundary.Responses;
+using UHResidentInformationAPI.V1.Domain;
 using UHResidentInformationAPI.V1.UseCase.Interfaces;
 
 namespace UHResidentInformationAPI.V1.Controllers
@@ -42,7 +42,7 @@ namespace UHResidentInformationAPI.V1.Controllers
         }
 
         [HttpGet]
-        [Route("/households/{houseReference}/people/{personReference}")]
+        [Route("{houseReference}/people/{personReference}")]
         public IActionResult ViewRecord(string houseReference, int personReference)
         {
             return Ok(_getResidentByIdUseCase.Execute(houseReference, personReference));


### PR DESCRIPTION
View endpoint route didn't have `api/v1` in its path.

**Before:**
This changes the routes be `/households/{house-ref}/people/{person-no}`

**After:**
This changes the routes be `/api/v1/households/{house-ref}/people/{person-no}`