### PR TITLE
Join on contact when both key1 and key2 are not null

### DIFF
--- a/UHResidentInformationAPI/V1/Gateways/UHGateway.cs
+++ b/UHResidentInformationAPI/V1/Gateways/UHGateway.cs
@@ -107,7 +107,7 @@ namespace UHResidentInformationAPI.V1.Gateways
             //Left Join on tagRef to get contactNo from cccontactLink
             var residentWithContacts = residentWithTagRefs
             .GroupJoin(
-                    _uHContext.ContactLinks,
+                    _uHContext.ContactLinks.Where(c => c.PersonNo != null && c.TagRef != null),
                     //Join on composite key to get list of contactno
                     anon => new { personno = anon.person.PersonNo.ToString(), tagref = anon.tenancy.TagRef.Trim() },
                     contact => new { personno = contact.PersonNo.Trim(), tagref = contact.TagRef.Trim() },


### PR DESCRIPTION
Some rows in the contact link table have no key1 and key2 values. 
When the query for listing all the residents starts a group join with contact link, it breaks when it tries to construct a composite key for an entry in the table that has no key1 and key2 value.

This adds a where clause to perform a group_join on values in the table that have both columns not equal to null.