### PR TITLE
Change phone types to match values in db

### DIFF
--- a/UHResidentInformationAPI.Tests/V1/E2ETests/ListResidentsReturnsAndQueriesAListOfAllResidents.cs
+++ b/UHResidentInformationAPI.Tests/V1/E2ETests/ListResidentsReturnsAndQueriesAListOfAllResidents.cs
@@ -28,6 +28,7 @@ namespace UHResidentInformationAPI.Tests.V1.E2ETests
             var expectedResidentResponseTwo = E2ETestHelpers.AddPersonWithRelatedEntitiesToDb(UHContext);
             var expectedResidentResponseThree = E2ETestHelpers.AddPersonWithRelatedEntitiesToDb(UHContext);
 
+
             var uri = new Uri("api/v1/households", UriKind.Relative);
             var response = Client.GetAsync(uri);
 

--- a/UHResidentInformationAPI.Tests/V1/Gateways/UHGatewayTests.cs
+++ b/UHResidentInformationAPI.Tests/V1/Gateways/UHGatewayTests.cs
@@ -89,7 +89,7 @@ namespace UHResidentInformationAPI.Tests.V1.Gateways
 
             var databasePhoneEntity = TestHelper.CreateDatabaseTelephoneNumberForPersonId(databaseContactLink.ContactID);
 
-            var type = (int) PhoneType.X;
+            var type = PhoneType.X;
             databasePhoneEntity.Type = type.ToString();
 
             UHContext.TelephoneNumbers.Add(databasePhoneEntity);

--- a/UHResidentInformationAPI.Tests/V1/Gateways/UHGatewayTests.cs
+++ b/UHResidentInformationAPI.Tests/V1/Gateways/UHGatewayTests.cs
@@ -89,7 +89,7 @@ namespace UHResidentInformationAPI.Tests.V1.Gateways
 
             var databasePhoneEntity = TestHelper.CreateDatabaseTelephoneNumberForPersonId(databaseContactLink.ContactID);
 
-            var type = (int) PhoneType.Primary;
+            var type = (int) PhoneType.X;
             databasePhoneEntity.Type = type.ToString();
 
             UHContext.TelephoneNumbers.Add(databasePhoneEntity);
@@ -100,7 +100,7 @@ namespace UHResidentInformationAPI.Tests.V1.Gateways
                 new Phone
                 {
                     PhoneNumber = databasePhoneEntity.Number,
-                    Type = PhoneType.Primary,
+                    Type = PhoneType.X,
                     LastModified = databasePhoneEntity.DateCreated
                 }
             };

--- a/UHResidentInformationAPI.Tests/V1/Helper/TestHelper.cs
+++ b/UHResidentInformationAPI.Tests/V1/Helper/TestHelper.cs
@@ -41,7 +41,7 @@ namespace UHResidentInformationAPI.Tests.V1.Helper
         public static TelephoneNumber CreateDatabaseTelephoneNumberForPersonId(int contactNo)
         {
             var fixture = new Fixture();
-            var fakePhoneType = (int) PhoneType.Mobile;
+            var fakePhoneType = (int) PhoneType.M;
 
             var fakeNumber = fixture.Build<TelephoneNumber>()
                 .With(tel => tel.ContactID, contactNo)

--- a/UHResidentInformationAPI.Tests/V1/Helper/TestHelper.cs
+++ b/UHResidentInformationAPI.Tests/V1/Helper/TestHelper.cs
@@ -41,7 +41,7 @@ namespace UHResidentInformationAPI.Tests.V1.Helper
         public static TelephoneNumber CreateDatabaseTelephoneNumberForPersonId(int contactNo)
         {
             var fixture = new Fixture();
-            var fakePhoneType = (int) PhoneType.M;
+            var fakePhoneType = PhoneType.M;
 
             var fakeNumber = fixture.Build<TelephoneNumber>()
                 .With(tel => tel.ContactID, contactNo)

--- a/UHResidentInformationAPI/V1/Enums/PhoneType.cs
+++ b/UHResidentInformationAPI/V1/Enums/PhoneType.cs
@@ -1,10 +1,13 @@
+using System.ComponentModel;
+
 namespace UHResidentInformationAPI.V1.Enums
 {
     public enum PhoneType
     {
-        Primary,
-        Home,
-        Mobile,
-        Fax
+        [Description("Home")] H,
+        [Description("Mobile")] M,
+        [Description("Fax")] F,
+        [Description("Work")] W,
+        X
     }
 }


### PR DESCRIPTION
**This PR:**
- Changes the phone type enums to be single letters representing a possible phone type. This corresponds to what was found in the DB e.g "P" instead of "Primary".
- Removes the conversion of the enum value to an integer. The column for the phone type is varchar(1) so we could instead return the single letter for phone type rather than an integer value.

**Question:**
- Are the descriptions for each enum correct?

**Open to any comments, feedback, suggestions on this.**