### PR TITLE
Catch "Not Found Exception" and return 404 status

### DIFF
--- a/UHResidentInformationAPI.Tests/V1/E2ETests/GetResidentInformationByIdTests.cs
+++ b/UHResidentInformationAPI.Tests/V1/E2ETests/GetResidentInformationByIdTests.cs
@@ -45,7 +45,7 @@ namespace UHResidentInformationAPI.Tests.V1.E2ETests
         [Test]
         public void GetHousingInformationByIdReturns404NotFound()
         {
-            var requestUri = new Uri($"/this/url/will/not/work", UriKind.Relative);
+            var requestUri = new Uri($"api/v1/households/0/people/0", UriKind.Relative);
             var response = Client.GetAsync(requestUri);
             var statusCode = response.Result.StatusCode;
             statusCode.Should().Be(404);

--- a/UHResidentInformationAPI/V1/Controllers/UHController.cs
+++ b/UHResidentInformationAPI/V1/Controllers/UHController.cs
@@ -45,7 +45,15 @@ namespace UHResidentInformationAPI.V1.Controllers
         [Route("{houseReference}/people/{personReference}")]
         public IActionResult ViewRecord(string houseReference, int personReference)
         {
-            return Ok(_getResidentByIdUseCase.Execute(houseReference, personReference));
+            try
+            {
+                var record = _getResidentByIdUseCase.Execute(houseReference, personReference);
+                return Ok(record);
+            }
+            catch (ResidentNotFoundException)
+            {
+                return NotFound();
+            }
         }
     };
 }


### PR DESCRIPTION
This adds a `try and catch` within the view endpoint controller action so that a `no resident found` exception is returned as a `404` rather than `500`