### PR TITLE
Return phone type as a single char string in the API response

### DIFF
--- a/UHResidentInformationAPI.Tests/V1/E2ETests/E2ETestHelper.cs
+++ b/UHResidentInformationAPI.Tests/V1/E2ETests/E2ETestHelper.cs
@@ -49,7 +49,7 @@ namespace UHResidentInformationAPI.Tests.V1.E2ETests
                         new Phone
                         {
                             PhoneNumber = phone.Number,
-                            PhoneType = Enum.Parse<PhoneType>(phone.Type),
+                            PhoneType = phone.Type,
                             LastModified = phone.DateCreated.ToString("O", CultureInfo.InvariantCulture)
                         }
                     },

--- a/UHResidentInformationAPI.Tests/V1/UseCase/GetResidentByIdUseCaseTests.cs
+++ b/UHResidentInformationAPI.Tests/V1/UseCase/GetResidentByIdUseCaseTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using UHResidentInformationAPI.V1.Domain;
+using UHResidentInformationAPI.V1.Enums;
 using UHResidentInformationAPI.V1.Factories;
 using UHResidentInformationAPI.V1.Gateways;
 using UHResidentInformationAPI.V1.UseCase;
@@ -28,7 +30,7 @@ namespace UHResidentInformationAPI.Tests.V1.UseCase
         }
 
         [Test]
-        public void ReturnsAClaimantInformationRecordWithAddressForTheSpecifiedID()
+        public void ReturnsAResidentInformationRecordWithAddressForTheSpecifiedID()
         {
             var stubbedResidentInfo = _fixture.Create<ResidentInformation>();
             var houseRef = _fixture.Create<string>();
@@ -46,7 +48,7 @@ namespace UHResidentInformationAPI.Tests.V1.UseCase
         }
 
         [Test]
-        public void ReturnsAClaimantInformationRecordWithOutAddressForTheSpecifiedID()
+        public void ReturnsAResidentInformationRecordWithOutAddressForTheSpecifiedID()
         {
             var stubbedResidentInfo = _fixture.Create<ResidentInformation>();
             var houseRef = _fixture.Create<string>();
@@ -63,6 +65,48 @@ namespace UHResidentInformationAPI.Tests.V1.UseCase
 
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void ReturnsAResidentInformationRecordWithOutPhoneTypeForTheSpecifiedID()
+        {
+            var stubbedResidentInfo = _fixture.Create<ResidentInformation>();
+            var houseRef = _fixture.Create<string>();
+            var personRef = _fixture.Create<int>();
+
+            stubbedResidentInfo.PhoneNumber.FirstOrDefault().Type = null;
+
+            _mockUhGateway.Setup(x =>
+                    x.GetResidentById(houseRef, personRef))
+                .Returns(stubbedResidentInfo);
+
+            var response = _classUnderTest.Execute(houseRef, personRef);
+            var expectedResponse = stubbedResidentInfo.ToResponse();
+
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(expectedResponse);
+            response.PhoneNumber.FirstOrDefault().PhoneType.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void ReturnsAResidentInformationRecordWithPhoneTypeForTheSpecifiedID()
+        {
+            var stubbedResidentInfo = _fixture.Create<ResidentInformation>();
+            var houseRef = _fixture.Create<string>();
+            var personRef = _fixture.Create<int>();
+
+            stubbedResidentInfo.PhoneNumber.FirstOrDefault().Type = PhoneType.F;
+
+            _mockUhGateway.Setup(x =>
+                    x.GetResidentById(houseRef, personRef))
+                .Returns(stubbedResidentInfo);
+
+            var response = _classUnderTest.Execute(houseRef, personRef);
+            var expectedResponse = stubbedResidentInfo.ToResponse();
+
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(expectedResponse);
+            response.PhoneNumber.FirstOrDefault().PhoneType.Should().Be("F");
         }
 
         [Test]

--- a/UHResidentInformationAPI/V1/Boundary/Responses/Phone.cs
+++ b/UHResidentInformationAPI/V1/Boundary/Responses/Phone.cs
@@ -5,7 +5,7 @@ namespace UHResidentInformationAPI.V1.Boundary.Responses
     public class Phone
     {
         public string PhoneNumber { get; set; }
-        public PhoneType? PhoneType { get; set; }
+        public string PhoneType { get; set; }
         public string LastModified { get; set; }
     }
 }

--- a/UHResidentInformationAPI/V1/Factories/ResponseFactory.cs
+++ b/UHResidentInformationAPI/V1/Factories/ResponseFactory.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using UHResidentInformationAPI.V1.Boundary.Responses;
+using UHResidentInformationAPI.V1.Enums;
 using Address = UHResidentInformationAPI.V1.Domain.Address;
 using AddressResponse = UHResidentInformationAPI.V1.Boundary.Responses.Address;
 using ResidentInformation = UHResidentInformationAPI.V1.Domain.ResidentInformation;
@@ -39,7 +41,7 @@ namespace UHResidentInformationAPI.V1.Factories
             return phoneNumbers.Select(number => new Phone
             {
                 PhoneNumber = number.PhoneNumber,
-                PhoneType = number.Type,
+                PhoneType = number.Type.ToString(),
                 LastModified = number.LastModified.ToString("O", CultureInfo.InvariantCulture)
             }).ToList();
         }


### PR DESCRIPTION
The response from endpoint still returned the `phonetype` as int values of the enum.
This would return the name of the constant defined in the enum.

**Open to suggestions, comments and feedback on this approach**